### PR TITLE
udpated calendar to agenda view

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 ### #BLM Protest Calendar
 <!-- <div class="btr-image" style="background-image: url('/static/img/blm-kids.jpg');"></div> -->
-<iframe src="https://calendar.google.com/calendar/embed?src=ohmdb20qqvfkk9gj53tgi73stk@group.calendar.google.com&ctz=America/Los_Angeles&pli=1" width="300" height="800" style="width: 100%; min-height: 500px; max-height: 95vh;"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=b2htZGIyMHFxdmZrazlnajUzdGdpNzNzdGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;mode=AGENDA&amp;showPrint=0&amp;showNav=0&amp;showTitle=0&amp;showDate=0&amp;showTabs=1&amp;showCalendars=0&amp;showTz=0" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 <div>Black Lives Matter protests in the Eugene, Springfield Area. <a href="/contact-us/">Click here</a> to let us know about your protest!</div>
 
 ### BoopTroop! Discord Community

--- a/pages/home.md
+++ b/pages/home.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 ### #BLM Protest Calendar
 <!-- <div class="btr-image" style="background-image: url('/static/img/blm-kids.jpg');"></div> -->
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=b2htZGIyMHFxdmZrazlnajUzdGdpNzNzdGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;mode=AGENDA&amp;showPrint=0&amp;showNav=0&amp;showTitle=0&amp;showDate=0&amp;showTabs=1&amp;showCalendars=0&amp;showTz=0" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=b2htZGIyMHFxdmZrazlnajUzdGdpNzNzdGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;mode=AGENDA&amp;showPrint=0&amp;showNav=0&amp;showTitle=0&amp;showDate=0&amp;showTabs=1&amp;showCalendars=0&amp;showTz=0" width="300" height="800" style="width: 100%; min-height: 500px; max-height: 95vh;" frameborder="0" scrolling="no"></iframe>
 <div>Black Lives Matter protests in the Eugene, Springfield Area. <a href="/contact-us/">Click here</a> to let us know about your protest!</div>
 
 ### BoopTroop! Discord Community


### PR DESCRIPTION
Just a little update to the iframe embed code so the calendar shows up in 'agenda' view by default, which is mobile friendlier. Also got rid of some of the other calendar UI to make it look a bit cleaner.